### PR TITLE
fix: use metric instead of IEC binary prefix

### DIFF
--- a/msnbase2.Rnw
+++ b/msnbase2.Rnw
@@ -279,7 +279,7 @@ p_access <-
   the in-memory (left) and on-disk (right) backends for 1, 10, 100
   1000, 5000 and all 6103 spectra. On-disk backend: blue. In-memory
   backend: red. Benchmarks were performed on a Dell XPS laptop with an
-  Intel i5-8250U processor 1.60 GHz (4 cores, 8 threads) and 7.5 GiB RAM
+  Intel i5-8250U processor 1.60 GHz (4 cores, 8 threads) and 7.5 GB RAM
   running Ubuntu 18.04.4 LTS 64-bit. }
 \label{fig:bench}
 \end{figure}


### PR DESCRIPTION
Again a minor change. But we should use metric or binary prefixes consistently. (I chose metric because we use metric prefixes in `show,MSnExp-method`).